### PR TITLE
fix(stats): use initiated_at to compute duration

### DIFF
--- a/packages/ds-collector/src/collector/service/statistic.service.ts
+++ b/packages/ds-collector/src/collector/service/statistic.service.ts
@@ -95,6 +95,6 @@ class StatisticService {
 export const statisticService = new StatisticService();
 
 // compute some dossier duration in days
-const computeDuration = (dossier: DSDossier) => differenceInDays(dossier.processed_at, dossier.created_at);
+const computeDuration = (dossier: DSDossier) => differenceInDays(dossier.processed_at, dossier.initiated_at);
 
 


### PR DESCRIPTION
Le champ `initiated_at` semble plus approprié